### PR TITLE
Implements a light cacheing strategy for when a post is made to a thread

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nodebb-plugin-imgbed",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "Creates an image tag to an image url that you post",
   "main": "library.js",
   "scripts": {
@@ -27,7 +27,8 @@
   "dependencies": {
     "xregexp": "3.0.x",
     "mkdirp": "0.5.x",
-    "winston": "^0.8.3"
+    "winston": "^0.8.3",
+    "cache-lru": "1.0.x"
   },
   "devDependencies": {
     "standard": "5.4.x",


### PR DESCRIPTION
This functionality was added because upon posting a message, the same content would be parsed 3 times, including the time it's parsed in the filter:parse.raw hook. Most of the time will be a cache miss while a message is being composed, (which you can see in debug mode) but it's a small lru cache, so it should have little to no impact on memory. 